### PR TITLE
Mark the package as replacing psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,12 @@
 		"interface",
 		"php7"
 	],
-    "extra": {
+	"extra": {
 		"branch-alias": {
 			"dev-master": "1.0.x-dev"
 		}
+	},
+	"replace": {
+		"psr/log": "1.0.2"
 	}
 }


### PR DESCRIPTION
This prevents issues if a person includes this while another dependency requires psr/log.

Fixes Issue #1 

Also corrects tab/space inconsistency.
